### PR TITLE
Improve Mina verification FFI

### DIFF
--- a/batcher/aligned-batcher/src/zk_utils/mod.rs
+++ b/batcher/aligned-batcher/src/zk_utils/mod.rs
@@ -4,8 +4,8 @@ use crate::sp1::verify_sp1_proof;
 use aligned_sdk::core::types::{ProvingSystemId, VerificationData};
 use ethers::types::U256;
 use log::{debug, warn};
-use mina_account_verifier_ffi::verify_account_inclusion_ffi;
-use mina_state_verifier_ffi::verify_mina_state_ffi;
+use mina_account_verifier_ffi::verify_account_inclusion;
+use mina_state_verifier_ffi::verify_mina_state;
 
 pub(crate) async fn verify(verification_data: &VerificationData) -> bool {
     let verification_data = verification_data.clone();
@@ -67,22 +67,7 @@ fn verify_internal(verification_data: &VerificationData) -> bool {
                 return false;
             };
 
-            const MAX_PROOF_SIZE: usize = 48 * 1024;
-            const MAX_PUB_INPUT_SIZE: usize = 6 * 1024;
-
-            let mut proof_buffer = [0; MAX_PROOF_SIZE];
-            for (buffer_item, proof_item) in proof_buffer.iter_mut().zip(&verification_data.proof) {
-                *buffer_item = *proof_item;
-            }
-            let proof_len = verification_data.proof.len();
-
-            let mut pub_input_buffer = [0; MAX_PUB_INPUT_SIZE];
-            for (buffer_item, pub_input_item) in pub_input_buffer.iter_mut().zip(pub_input) {
-                *buffer_item = *pub_input_item;
-            }
-            let pub_input_len = pub_input.len();
-
-            verify_mina_state_ffi(&proof_buffer, proof_len, &pub_input_buffer, pub_input_len)
+            verify_mina_state(&verification_data.proof, &pub_input)
         }
         ProvingSystemId::MinaAccount => {
             let Some(pub_input) = verification_data.pub_input.as_ref() else {
@@ -90,22 +75,7 @@ fn verify_internal(verification_data: &VerificationData) -> bool {
                 return false;
             };
 
-            const MAX_PROOF_SIZE: usize = 16 * 1024;
-            const MAX_PUB_INPUT_SIZE: usize = 6 * 1024;
-
-            let mut proof_buffer = [0; MAX_PROOF_SIZE];
-            for (buffer_item, proof_item) in proof_buffer.iter_mut().zip(&verification_data.proof) {
-                *buffer_item = *proof_item;
-            }
-            let proof_len = verification_data.proof.len();
-
-            let mut pub_input_buffer = [0; MAX_PUB_INPUT_SIZE];
-            for (buffer_item, pub_input_item) in pub_input_buffer.iter_mut().zip(pub_input) {
-                *buffer_item = *pub_input_item;
-            }
-            let pub_input_len = pub_input.len();
-
-            verify_account_inclusion_ffi(&proof_buffer, proof_len, &pub_input_buffer, pub_input_len)
+            verify_account_inclusion(&verification_data.proof, &pub_input)
         }
     }
 }

--- a/operator/mina/lib/mina_verifier.h
+++ b/operator/mina/lib/mina_verifier.h
@@ -1,6 +1,6 @@
 #include <stdbool.h>
+#include <stdint.h>
 
-bool verify_mina_state_ffi(unsigned char *proof_buffer,
-                            unsigned int proof_len,
-                            unsigned char *pub_input_buffer,
-                            unsigned int pub_input_len);
+int32_t verify_mina_state_ffi(unsigned char *proof_buffer, uint32_t proof_len,
+                              unsigned char *pub_input_buffer,
+                              uint32_t pub_input_len);

--- a/operator/mina/lib/src/lib.rs
+++ b/operator/mina/lib/src/lib.rs
@@ -37,9 +37,25 @@ lazy_static! {
 #[no_mangle]
 pub extern "C" fn verify_mina_state_ffi(
     proof_bytes: *const u8,
-    proof_len: usize,
+    proof_len: u32,
     pub_input_bytes: *const u8,
-    pub_input_len: usize,
+    pub_input_len: u32,
+) -> i32 {
+    let result = std::panic::catch_unwind(|| {
+        inner_verify_mina_state_ffi(proof_bytes, proof_len, pub_input_bytes, pub_input_len)
+    });
+
+    match result {
+        Ok(v) => v as i32,
+        Err(_) => -1,
+    }
+}
+
+fn inner_verify_mina_state_ffi(
+    proof_bytes: *const u8,
+    proof_len: u32,
+    pub_input_bytes: *const u8,
+    pub_input_len: u32,
 ) -> bool {
     if proof_bytes.is_null() || pub_input_bytes.is_null() {
         error!("Input buffer null");
@@ -233,105 +249,51 @@ mod test {
 
     #[test]
     fn valid_mina_state_proof_verifies() {
-        let mut proof_buffer = [0u8; PROOF_BYTES.len()];
-        let proof_size = PROOF_BYTES.len();
-        assert!(proof_size <= proof_buffer.len());
-        proof_buffer[..proof_size].clone_from_slice(PROOF_BYTES);
-
-        let mut pub_input_buffer = [0u8; super::MAX_PUB_INPUT_SIZE];
-        let pub_input_size = PUB_INPUT_BYTES.len();
-        assert!(pub_input_size <= pub_input_buffer.len());
-        pub_input_buffer[..pub_input_size].clone_from_slice(PUB_INPUT_BYTES);
-
-        let result =
-            verify_mina_state_ffi(&proof_buffer, proof_size, &pub_input_buffer, pub_input_size);
-        assert!(result);
+        let result = verify_mina_state_ffi(
+            PROOF_BYTES.as_ptr(),
+            PROOF_BYTES.len() as u32,
+            PUB_INPUT_BYTES.as_ptr(),
+            PUB_INPUT_BYTES.len() as u32,
+        );
+        assert_eq!(result, 1);
     }
 
     #[test]
     fn mina_state_proof_with_bad_bridge_tip_hash_does_not_verify() {
-        let mut proof_buffer = [0u8; PROOF_BYTES.len()];
-        let proof_size = PROOF_BYTES.len();
-        assert!(proof_size <= proof_buffer.len());
-        proof_buffer[..proof_size].clone_from_slice(PROOF_BYTES);
-
-        let mut pub_input_buffer = [0u8; super::MAX_PUB_INPUT_SIZE];
-        let pub_input_size = BAD_HASH_PUB_INPUT_BYTES.len();
-        assert!(pub_input_size <= pub_input_buffer.len());
-        pub_input_buffer[..pub_input_size].clone_from_slice(BAD_HASH_PUB_INPUT_BYTES);
-
-        let result =
-            verify_mina_state_ffi(&proof_buffer, proof_size, &pub_input_buffer, pub_input_size);
-        assert!(!result);
+        let result = verify_mina_state_ffi(
+            PROOF_BYTES.as_ptr(),
+            PROOF_BYTES.len() as u32,
+            BAD_HASH_PUB_INPUT_BYTES.as_ptr(),
+            BAD_HASH_PUB_INPUT_BYTES.len() as u32,
+        );
+        assert_eq!(result, 0);
     }
 
     #[test]
     fn empty_mina_state_proof_does_not_verify() {
-        let proof_buffer = [0u8; PROOF_BYTES.len()];
-        let proof_size = PROOF_BYTES.len();
+        const PROOF_SIZE: usize = PROOF_BYTES.len();
+        let empty_proof_buffer = [0u8; PROOF_SIZE];
 
-        let mut pub_input_buffer = [0u8; super::MAX_PUB_INPUT_SIZE];
-        let pub_input_size = PUB_INPUT_BYTES.len();
-        assert!(pub_input_size <= pub_input_buffer.len());
-        pub_input_buffer[..pub_input_size].clone_from_slice(PUB_INPUT_BYTES);
-
-        let result =
-            verify_mina_state_ffi(&proof_buffer, proof_size, &pub_input_buffer, pub_input_size);
-        assert!(!result);
+        let result = verify_mina_state_ffi(
+            empty_proof_buffer.as_ptr(),
+            PROOF_SIZE as u32,
+            PUB_INPUT_BYTES.as_ptr(),
+            PUB_INPUT_BYTES.len() as u32,
+        );
+        assert_eq!(result, 0);
     }
 
     #[test]
     fn valid_mina_state_proof_with_empty_pub_input_does_not_verify() {
-        let mut proof_buffer = [0u8; PROOF_BYTES.len()];
-        let proof_size = PROOF_BYTES.len();
-        assert!(proof_size <= proof_buffer.len());
-        proof_buffer[..proof_size].clone_from_slice(PROOF_BYTES);
-
-        let pub_input_buffer = [0u8; super::MAX_PUB_INPUT_SIZE];
-        let pub_input_size = PUB_INPUT_BYTES.len();
-
-        let result =
-            verify_mina_state_ffi(&proof_buffer, proof_size, &pub_input_buffer, pub_input_size);
-        assert!(!result);
-    }
-
-    #[test]
-    fn valid_mina_state_proof_with_greater_proof_size_does_not_verify() {
-        let mut proof_buffer = [0u8; PROOF_BYTES.len()];
-        let wrong_proof_size = PROOF_BYTES.len() + 1;
-        proof_buffer[..PROOF_BYTES.len()].clone_from_slice(PROOF_BYTES);
-
-        let mut pub_input_buffer = [0u8; super::MAX_PUB_INPUT_SIZE];
-        let pub_input_size = PUB_INPUT_BYTES.len();
-        assert!(pub_input_size <= pub_input_buffer.len());
-        pub_input_buffer[..pub_input_size].clone_from_slice(PUB_INPUT_BYTES);
+        const PUB_INPUT_SIZE: usize = PUB_INPUT_BYTES.len();
+        let empty_pub_input_buffer = [0u8; PUB_INPUT_SIZE];
 
         let result = verify_mina_state_ffi(
-            &proof_buffer,
-            wrong_proof_size,
-            &pub_input_buffer,
-            pub_input_size,
+            PROOF_BYTES.as_ptr(),
+            PROOF_BYTES.len() as u32,
+            empty_pub_input_buffer.as_ptr(),
+            PUB_INPUT_SIZE as u32,
         );
-        assert!(!result);
-    }
-
-    #[test]
-    fn valid_mina_state_proof_with_greater_pub_input_size_does_not_verify() {
-        let mut proof_buffer = [0u8; PROOF_BYTES.len()];
-        let proof_size = PROOF_BYTES.len();
-        assert!(proof_size <= proof_buffer.len());
-        proof_buffer[..proof_size].clone_from_slice(PROOF_BYTES);
-
-        let mut pub_input_buffer = [0u8; super::MAX_PUB_INPUT_SIZE];
-        let wrong_pub_input_size = MAX_PUB_INPUT_SIZE + 1;
-        pub_input_buffer[..PUB_INPUT_BYTES.len()].clone_from_slice(PUB_INPUT_BYTES);
-
-        let result = verify_mina_state_ffi(
-            &proof_buffer,
-            proof_size,
-            &pub_input_buffer,
-            wrong_pub_input_size,
-        );
-        assert!(!result);
+        assert_eq!(result, 0);
     }
 }

--- a/operator/mina/lib/src/lib.rs
+++ b/operator/mina/lib/src/lib.rs
@@ -70,7 +70,7 @@ fn inner_verify_mina_state_ffi(
     let proof_bytes = unsafe { std::slice::from_raw_parts(proof_bytes, proof_len as usize) };
 
     let pub_input_bytes =
-        unsafe { std::slice::from_raw_parts(pub_input_bytes, proof_len as usize) };
+        unsafe { std::slice::from_raw_parts(pub_input_bytes, pub_input_len as usize) };
 
     verify_mina_state(proof_bytes, pub_input_bytes)
 }

--- a/operator/mina/lib/src/lib.rs
+++ b/operator/mina/lib/src/lib.rs
@@ -34,35 +34,40 @@ lazy_static! {
     static ref MINA_SRS: SRS<Vesta> = SRS::<Vesta>::create(Fq::SRS_DEPTH);
 }
 
-// TODO(xqft): check proof size
-const MAX_PROOF_SIZE: usize = 48 * 1024;
-const MAX_PUB_INPUT_SIZE: usize = 6 * 1024;
-
 #[no_mangle]
 pub extern "C" fn verify_mina_state_ffi(
-    proof_buffer: &[u8; MAX_PROOF_SIZE],
+    proof_bytes: *const u8,
     proof_len: usize,
-    pub_input_buffer: &[u8; MAX_PUB_INPUT_SIZE],
+    pub_input_bytes: *const u8,
     pub_input_len: usize,
 ) -> bool {
-    let Some(proof_buffer_slice) = proof_buffer.get(..proof_len) else {
-        error!("Proof length argument is greater than max proof size");
+    if proof_bytes.is_null() || pub_input_bytes.is_null() {
+        error!("Input buffer null");
         return false;
-    };
+    }
 
-    let Some(pub_input_buffer_slice) = pub_input_buffer.get(..pub_input_len) else {
-        error!("Public input length argument is greater than max public input size");
+    if proof_len == 0 || pub_input_len == 0 {
+        error!("Input buffer length zero size");
         return false;
-    };
+    }
 
-    let proof: MinaStateProof = match bincode::deserialize(proof_buffer_slice) {
+    let proof_bytes = unsafe { std::slice::from_raw_parts(proof_bytes, proof_len as usize) };
+
+    let pub_input_bytes =
+        unsafe { std::slice::from_raw_parts(pub_input_bytes, proof_len as usize) };
+
+    verify_mina_state(proof_bytes, pub_input_bytes)
+}
+
+pub fn verify_mina_state(proof_bytes: &[u8], pub_input_bytes: &[u8]) -> bool {
+    let proof: MinaStateProof = match bincode::deserialize(proof_bytes) {
         Ok(proof) => proof,
         Err(err) => {
             error!("Failed to deserialize state proof: {}", err);
             return false;
         }
     };
-    let pub_inputs: MinaStatePubInputs = match bincode::deserialize(pub_input_buffer_slice) {
+    let pub_inputs: MinaStatePubInputs = match bincode::deserialize(pub_input_bytes) {
         Ok(pub_inputs) => pub_inputs,
         Err(err) => {
             error!("Failed to deserialize state pub inputs: {}", err);
@@ -228,7 +233,7 @@ mod test {
 
     #[test]
     fn valid_mina_state_proof_verifies() {
-        let mut proof_buffer = [0u8; super::MAX_PROOF_SIZE];
+        let mut proof_buffer = [0u8; PROOF_BYTES.len()];
         let proof_size = PROOF_BYTES.len();
         assert!(proof_size <= proof_buffer.len());
         proof_buffer[..proof_size].clone_from_slice(PROOF_BYTES);
@@ -245,7 +250,7 @@ mod test {
 
     #[test]
     fn mina_state_proof_with_bad_bridge_tip_hash_does_not_verify() {
-        let mut proof_buffer = [0u8; super::MAX_PROOF_SIZE];
+        let mut proof_buffer = [0u8; PROOF_BYTES.len()];
         let proof_size = PROOF_BYTES.len();
         assert!(proof_size <= proof_buffer.len());
         proof_buffer[..proof_size].clone_from_slice(PROOF_BYTES);
@@ -262,7 +267,7 @@ mod test {
 
     #[test]
     fn empty_mina_state_proof_does_not_verify() {
-        let proof_buffer = [0u8; super::MAX_PROOF_SIZE];
+        let proof_buffer = [0u8; PROOF_BYTES.len()];
         let proof_size = PROOF_BYTES.len();
 
         let mut pub_input_buffer = [0u8; super::MAX_PUB_INPUT_SIZE];
@@ -277,7 +282,7 @@ mod test {
 
     #[test]
     fn valid_mina_state_proof_with_empty_pub_input_does_not_verify() {
-        let mut proof_buffer = [0u8; super::MAX_PROOF_SIZE];
+        let mut proof_buffer = [0u8; PROOF_BYTES.len()];
         let proof_size = PROOF_BYTES.len();
         assert!(proof_size <= proof_buffer.len());
         proof_buffer[..proof_size].clone_from_slice(PROOF_BYTES);
@@ -292,8 +297,8 @@ mod test {
 
     #[test]
     fn valid_mina_state_proof_with_greater_proof_size_does_not_verify() {
-        let mut proof_buffer = [0u8; super::MAX_PROOF_SIZE];
-        let wrong_proof_size = super::MAX_PROOF_SIZE + 1;
+        let mut proof_buffer = [0u8; PROOF_BYTES.len()];
+        let wrong_proof_size = PROOF_BYTES.len() + 1;
         proof_buffer[..PROOF_BYTES.len()].clone_from_slice(PROOF_BYTES);
 
         let mut pub_input_buffer = [0u8; super::MAX_PUB_INPUT_SIZE];
@@ -312,7 +317,7 @@ mod test {
 
     #[test]
     fn valid_mina_state_proof_with_greater_pub_input_size_does_not_verify() {
-        let mut proof_buffer = [0u8; super::MAX_PROOF_SIZE];
+        let mut proof_buffer = [0u8; PROOF_BYTES.len()];
         let proof_size = PROOF_BYTES.len();
         assert!(proof_size <= proof_buffer.len());
         proof_buffer[..proof_size].clone_from_slice(PROOF_BYTES);

--- a/operator/mina/mina.go
+++ b/operator/mina/mina.go
@@ -13,10 +13,6 @@ import (
 	"unsafe"
 )
 
-// TODO(xqft): check proof size
-const MAX_PROOF_SIZE = 48 * 1024
-const MAX_PUB_INPUT_SIZE = 6 * 1024
-
 func timer() func() {
 	start := time.Now()
 	return func() {
@@ -24,8 +20,13 @@ func timer() func() {
 	}
 }
 
-func VerifyMinaState(proofBuffer [MAX_PROOF_SIZE]byte, proofLen uint, pubInputBuffer [MAX_PUB_INPUT_SIZE]byte, pubInputLen uint) bool {
+func VerifyMinaState(proofBuffer []byte, proofLen uint, pubInputBuffer []byte, pubInputLen uint) bool {
 	defer timer()()
+
+	if len(proofBuffer) == 0 || len(pubInputBuffer) == 0 {
+		return false
+	}
+
 	proofPtr := (*C.uchar)(unsafe.Pointer(&proofBuffer[0]))
 	pubInputPtr := (*C.uchar)(unsafe.Pointer(&pubInputBuffer[0]))
 	return (bool)(C.verify_mina_state_ffi(proofPtr, (C.uint)(proofLen), pubInputPtr, (C.uint)(pubInputLen)))

--- a/operator/mina/mina.go
+++ b/operator/mina/mina.go
@@ -9,25 +9,36 @@ package mina
 import "C"
 import (
 	"fmt"
-	"time"
 	"unsafe"
 )
 
-func timer() func() {
-	start := time.Now()
-	return func() {
-		fmt.Printf("Mina block verification took %v\n", time.Since(start))
-	}
-}
-
-func VerifyMinaState(proofBuffer []byte, proofLen uint, pubInputBuffer []byte, pubInputLen uint) bool {
-	defer timer()()
-
+func VerifyMinaState(proofBuffer []byte, pubInputBuffer []byte) (isVerified bool, err error) {
+	// Here we define the return value on failure
+	isVerified = false
+	err = nil
 	if len(proofBuffer) == 0 || len(pubInputBuffer) == 0 {
-		return false
+		return isVerified, err
 	}
+
+	// This will catch any go panic
+	defer func() {
+		rec := recover()
+		if rec != nil {
+			err = fmt.Errorf("Panic was caught while verifying sp1 proof: %s", rec)
+		}
+	}()
 
 	proofPtr := (*C.uchar)(unsafe.Pointer(&proofBuffer[0]))
 	pubInputPtr := (*C.uchar)(unsafe.Pointer(&pubInputBuffer[0]))
-	return (bool)(C.verify_mina_state_ffi(proofPtr, (C.uint)(proofLen), pubInputPtr, (C.uint)(pubInputLen)))
+
+	r := (C.int32_t)(C.verify_mina_state_ffi(proofPtr, (C.uint32_t)(len(proofBuffer)), pubInputPtr, (C.uint32_t)(len(pubInputBuffer))))
+
+	if r == -1 {
+		err = fmt.Errorf("Panic happened on FFI while verifying Mina proof")
+		return isVerified, err
+	}
+
+	isVerified = (r == 1)
+
+	return isVerified, err
 }

--- a/operator/mina/mina_test.go
+++ b/operator/mina/mina_test.go
@@ -1,77 +1,71 @@
 package mina_test
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
 	"github.com/yetanotherco/aligned_layer/operator/mina"
 )
 
+const ProofFilePath = "../../scripts/test_files/mina/mina_state.proof"
+
+const PubInputFilePath = "../../scripts/test_files/mina/mina_state.pub"
+
 func TestMinaStateProofVerifies(t *testing.T) {
-	fmt.Println(os.Getwd())
-	proofFile, err := os.Open("../../scripts/test_files/mina/mina_state.proof")
+	proofBytes, err := os.ReadFile(ProofFilePath)
 	if err != nil {
 		t.Errorf("could not open mina state proof file")
 	}
 
-	proofBuffer := make([]byte, mina.MAX_PROOF_SIZE)
-	proofLen, err := proofFile.Read(proofBuffer)
+	pubInputBytes, err := os.ReadFile(PubInputFilePath)
 	if err != nil {
-		t.Errorf("could not read bytes from mina state proof file")
+		t.Errorf("could not open mina state pub input file")
 	}
 
-	pubInputFile, err := os.Open("../../scripts/test_files/mina/mina_state.pub")
-	if err != nil {
-		t.Errorf("could not open mina state hash file")
-	}
-	pubInputBuffer := make([]byte, mina.MAX_PUB_INPUT_SIZE)
-	pubInputLen, err := pubInputFile.Read(pubInputBuffer)
-	if err != nil {
-		t.Errorf("could not read bytes from mina state hash")
-	}
-
-	if !mina.VerifyMinaState(([mina.MAX_PROOF_SIZE]byte)(proofBuffer), uint(proofLen), ([mina.MAX_PUB_INPUT_SIZE]byte)(pubInputBuffer), uint(pubInputLen)) {
+	verified, err := mina.VerifyMinaState(proofBytes, pubInputBytes)
+	if err != nil || !verified {
 		t.Errorf("proof did not verify")
 	}
 }
 
 func TestEmptyMinaStateProofDoesNotVerify(t *testing.T) {
-	fmt.Println(os.Getwd())
-
-	proofBuffer := make([]byte, mina.MAX_PROOF_SIZE)
-
-	pubInputFile, err := os.Open("../../scripts/test_files/mina/mina_state.pub")
+	proofBytes, err := os.ReadFile(ProofFilePath)
 	if err != nil {
-		t.Errorf("could not open mina state hash file")
+		t.Errorf("could not open mina state proof file")
 	}
-	pubInputBuffer := make([]byte, mina.MAX_PUB_INPUT_SIZE)
-	pubInputLen, err := pubInputFile.Read(pubInputBuffer)
+	emptyProofBuffer := make([]byte, len(proofBytes))
+
+	pubInputBytes, err := os.ReadFile(PubInputFilePath)
 	if err != nil {
-		t.Errorf("could not read bytes from mina state hash")
+		t.Errorf("could not open mina state pub input file")
 	}
 
-	if mina.VerifyMinaState(([mina.MAX_PROOF_SIZE]byte)(proofBuffer), mina.MAX_PROOF_SIZE, ([mina.MAX_PUB_INPUT_SIZE]byte)(pubInputBuffer), uint(pubInputLen)) {
-		t.Errorf("empty proof should not verify but it did")
+	verified, err := mina.VerifyMinaState(emptyProofBuffer, pubInputBytes)
+	if err != nil {
+		t.Errorf("verification failed with error")
+	}
+	if verified {
+		t.Errorf("proof should not verify")
 	}
 }
 
 func TestMinaStateProofWithEmptyPubInputDoesNotVerify(t *testing.T) {
-	fmt.Println(os.Getwd())
-	proofFile, err := os.Open("../../scripts/test_files/mina/mina_state.proof")
+	proofBytes, err := os.ReadFile(ProofFilePath)
 	if err != nil {
 		t.Errorf("could not open mina state proof file")
 	}
 
-	proofBuffer := make([]byte, mina.MAX_PROOF_SIZE)
-	proofLen, err := proofFile.Read(proofBuffer)
+	pubInputBytes, err := os.ReadFile(PubInputFilePath)
 	if err != nil {
-		t.Errorf("could not read bytes from mina state proof file")
+		t.Errorf("could not open mina state pub input file")
 	}
+	emptyPubInputBuffer := make([]byte, len(pubInputBytes))
 
-	pubInputBuffer := make([]byte, mina.MAX_PUB_INPUT_SIZE)
-
-	if mina.VerifyMinaState(([mina.MAX_PROOF_SIZE]byte)(proofBuffer), uint(proofLen), ([mina.MAX_PUB_INPUT_SIZE]byte)(pubInputBuffer), mina.MAX_PUB_INPUT_SIZE) {
-		t.Errorf("proof with no public inputs should not verify but it did")
+	verified, err := mina.VerifyMinaState(proofBytes, emptyPubInputBuffer)
+	if err != nil {
+		t.Errorf("verification failed with error")
+	}
+	if verified {
+		t.Errorf("proof should not verify")
 	}
 }

--- a/operator/mina_account/lib/mina_account_verifier.h
+++ b/operator/mina_account/lib/mina_account_verifier.h
@@ -1,6 +1,7 @@
 #include <stdbool.h>
+#include <stdint.h>
 
-bool verify_account_inclusion_ffi(unsigned char *proof_buffer,
-                                  unsigned int proof_len,
-                                  unsigned char *public_input_buffer,
-                                  unsigned int public_input_len);
+int32_t verify_account_inclusion_ffi(unsigned char *proof_buffer,
+                                     uint32_t proof_len,
+                                     unsigned char *public_input_buffer,
+                                     uint32_t public_input_len);

--- a/operator/mina_account/lib/src/lib.rs
+++ b/operator/mina_account/lib/src/lib.rs
@@ -12,9 +12,25 @@ mod merkle_verifier;
 #[no_mangle]
 pub extern "C" fn verify_account_inclusion_ffi(
     proof_bytes: *const u8,
-    proof_len: usize,
+    proof_len: u32,
     pub_input_bytes: *const u8,
-    pub_input_len: usize,
+    pub_input_len: u32,
+) -> i32 {
+    let result = std::panic::catch_unwind(|| {
+        inner_verify_account_inclusion_ffi(proof_bytes, proof_len, pub_input_bytes, pub_input_len)
+    });
+
+    match result {
+        Ok(v) => v as i32,
+        Err(_) => -1,
+    }
+}
+
+fn inner_verify_account_inclusion_ffi(
+    proof_bytes: *const u8,
+    proof_len: u32,
+    pub_input_bytes: *const u8,
+    pub_input_len: u32,
 ) -> bool {
     if proof_bytes.is_null() || pub_input_bytes.is_null() {
         error!("Input buffer null");
@@ -29,7 +45,7 @@ pub extern "C" fn verify_account_inclusion_ffi(
     let proof_bytes = unsafe { std::slice::from_raw_parts(proof_bytes, proof_len as usize) };
 
     let pub_input_bytes =
-        unsafe { std::slice::from_raw_parts(pub_input_bytes, proof_len as usize) };
+        unsafe { std::slice::from_raw_parts(pub_input_bytes, pub_input_len as usize) };
 
     verify_account_inclusion(proof_bytes, pub_input_bytes)
 }
@@ -45,6 +61,7 @@ pub fn verify_account_inclusion(proof_bytes: &[u8], pub_input_bytes: &[u8]) -> b
             return false;
         }
     };
+    error!("pub input len: {}", pub_input_bytes.len());
     let MinaAccountPubInputs {
         ledger_hash,
         encoded_account,
@@ -94,80 +111,50 @@ mod test {
 
     #[test]
     fn valid_account_state_proof_verifies() {
-        let result = verify_account_inclusion(PROOF_BYTES, PUB_INPUT_BYTES);
-        assert!(result);
+        let mut proof_buffer = [0u8; PROOF_BYTES.len()];
+        let proof_size = PROOF_BYTES.len();
+        assert!(proof_size <= proof_buffer.len());
+        proof_buffer[..proof_size].clone_from_slice(PROOF_BYTES);
+
+        let mut pub_input_buffer = [0u8; PUB_INPUT_BYTES.len()];
+        let pub_input_size = PUB_INPUT_BYTES.len();
+        assert!(pub_input_size <= pub_input_buffer.len());
+        pub_input_buffer[..pub_input_size].clone_from_slice(PUB_INPUT_BYTES);
+
+        let result = verify_account_inclusion_ffi(
+            proof_buffer.as_ptr(),
+            proof_size as u32,
+            pub_input_buffer.as_ptr(),
+            pub_input_size as u32,
+        );
+        assert_eq!(result, 1);
     }
 
     #[test]
     fn empty_account_state_proof_does_not_verify() {
-        let proof_buffer = [0u8; PROOF_BYTES.len()];
-        let proof_size = PROOF_BYTES.len();
+        const PROOF_SIZE: usize = PROOF_BYTES.len();
+        let proof_buffer = [0u8; PROOF_SIZE];
 
-        let mut pub_input_buffer = [0u8; super::MAX_PUB_INPUT_SIZE];
-        let pub_input_size = PUB_INPUT_BYTES.len();
-        assert!(pub_input_size <= pub_input_buffer.len());
-        pub_input_buffer[..pub_input_size].clone_from_slice(PUB_INPUT_BYTES);
-
-        let result = verify_account_inclusion(&proof_buffer, &pub_input_buffer, pub_input_size);
-        assert!(!result);
+        let result = verify_account_inclusion_ffi(
+            proof_buffer.as_ptr(),
+            PROOF_SIZE as u32,
+            PUB_INPUT_BYTES.as_ptr(),
+            PUB_INPUT_BYTES.len() as u32,
+        );
+        assert_eq!(result, 0);
     }
 
     #[test]
     fn valid_account_state_proof_with_empty_pub_input_does_not_verify() {
-        let mut proof_buffer = [0u8; PROOF_BYTES.len()];
-        let proof_size = PROOF_BYTES.len();
-        assert!(proof_size <= proof_buffer.len());
-        proof_buffer[..proof_size].clone_from_slice(PROOF_BYTES);
-
-        let pub_input_buffer = [0u8; super::MAX_PUB_INPUT_SIZE];
-        let pub_input_size = PUB_INPUT_BYTES.len();
+        const PUB_INPUT_SIZE: usize = PUB_INPUT_BYTES.len();
+        let pub_input_buffer = [0u8; PUB_INPUT_SIZE];
 
         let result = verify_account_inclusion_ffi(
-            &proof_buffer,
-            proof_size,
-            &pub_input_buffer,
-            pub_input_size,
+            PROOF_BYTES.as_ptr(),
+            PROOF_BYTES.len() as u32,
+            pub_input_buffer.as_ptr(),
+            PUB_INPUT_SIZE as u32,
         );
-        assert!(!result);
-    }
-
-    #[test]
-    fn valid_account_state_proof_with_greater_proof_size_does_not_verify() {
-        let mut proof_buffer = [0u8; PROOF_BYTES.len()];
-        let wrong_proof_size = MAX_PROOF_SIZE + 1;
-        proof_buffer[..PROOF_BYTES.len()].clone_from_slice(PROOF_BYTES);
-
-        let mut pub_input_buffer = [0u8; super::MAX_PUB_INPUT_SIZE];
-        let pub_input_size = PUB_INPUT_BYTES.len();
-        assert!(pub_input_size <= pub_input_buffer.len());
-        pub_input_buffer[..pub_input_size].clone_from_slice(PUB_INPUT_BYTES);
-
-        let result = verify_account_inclusion_ffi(
-            &proof_buffer,
-            wrong_proof_size,
-            &pub_input_buffer,
-            pub_input_size,
-        );
-        assert!(!result);
-    }
-
-    #[test]
-    fn valid_account_state_proof_with_greater_pub_input_size_does_not_verify() {
-        let mut proof_buffer = [0u8; PROOF_BYTES.len()];
-        let proof_size = PROOF_BYTES.len();
-        assert!(proof_size <= proof_buffer.len());
-        proof_buffer[..proof_size].clone_from_slice(PROOF_BYTES);
-
-        let mut pub_input_buffer = [0u8; super::MAX_PUB_INPUT_SIZE];
-        let wrong_pub_input_size = MAX_PUB_INPUT_SIZE + 1;
-        pub_input_buffer[..PUB_INPUT_BYTES.len()].clone_from_slice(PUB_INPUT_BYTES);
-
-        let result = verify_account_inclusion_ffi(
-            &proof_buffer,
-            proof_size,
-            &pub_input_buffer,
-            wrong_pub_input_size,
-        );
-        assert!(!result);
+        assert_eq!(result, 0);
     }
 }

--- a/operator/mina_account/lib/src/lib.rs
+++ b/operator/mina_account/lib/src/lib.rs
@@ -9,31 +9,36 @@ use mina_tree::Account;
 
 mod merkle_verifier;
 
-// TODO(xqft): check sizes
-const MAX_PROOF_SIZE: usize = 16 * 1024;
-const MAX_PUB_INPUT_SIZE: usize = 6 * 1024;
-
 #[no_mangle]
 pub extern "C" fn verify_account_inclusion_ffi(
-    proof_buffer: &[u8; MAX_PROOF_SIZE],
+    proof_bytes: *const u8,
     proof_len: usize,
-    pub_input_buffer: &[u8; MAX_PUB_INPUT_SIZE],
+    pub_input_bytes: *const u8,
     pub_input_len: usize,
 ) -> bool {
-    let Some(proof_buffer_slice) = proof_buffer.get(..proof_len) else {
-        error!("Proof length argument is greater than max proof size");
+    if proof_bytes.is_null() || pub_input_bytes.is_null() {
+        error!("Input buffer null");
         return false;
-    };
+    }
 
-    let Some(pub_input_buffer_slice) = pub_input_buffer.get(..pub_input_len) else {
-        error!("Public input length argument is greater than max public input size");
+    if proof_len == 0 || pub_input_len == 0 {
+        error!("Input buffer length zero size");
         return false;
-    };
+    }
 
+    let proof_bytes = unsafe { std::slice::from_raw_parts(proof_bytes, proof_len as usize) };
+
+    let pub_input_bytes =
+        unsafe { std::slice::from_raw_parts(pub_input_bytes, proof_len as usize) };
+
+    verify_account_inclusion(proof_bytes, pub_input_bytes)
+}
+
+pub fn verify_account_inclusion(proof_bytes: &[u8], pub_input_bytes: &[u8]) -> bool {
     let MinaAccountProof {
         merkle_path,
         account,
-    } = match bincode::deserialize(proof_buffer_slice) {
+    } = match bincode::deserialize(proof_bytes) {
         Ok(proof) => proof,
         Err(err) => {
             error!("Failed to deserialize account proof: {}", err);
@@ -43,7 +48,7 @@ pub extern "C" fn verify_account_inclusion_ffi(
     let MinaAccountPubInputs {
         ledger_hash,
         encoded_account,
-    } = match bincode::deserialize(pub_input_buffer_slice) {
+    } = match bincode::deserialize(pub_input_bytes) {
         Ok(pub_inputs) => pub_inputs,
         Err(err) => {
             error!("Failed to deserialize account pub inputs: {}", err);
@@ -89,28 +94,13 @@ mod test {
 
     #[test]
     fn valid_account_state_proof_verifies() {
-        let mut proof_buffer = [0u8; super::MAX_PROOF_SIZE];
-        let proof_size = PROOF_BYTES.len();
-        assert!(proof_size <= proof_buffer.len());
-        proof_buffer[..proof_size].clone_from_slice(PROOF_BYTES);
-
-        let mut pub_input_buffer = [0u8; super::MAX_PUB_INPUT_SIZE];
-        let pub_input_size = PUB_INPUT_BYTES.len();
-        assert!(pub_input_size <= pub_input_buffer.len());
-        pub_input_buffer[..pub_input_size].clone_from_slice(PUB_INPUT_BYTES);
-
-        let result = verify_account_inclusion_ffi(
-            &proof_buffer,
-            proof_size,
-            &pub_input_buffer,
-            pub_input_size,
-        );
+        let result = verify_account_inclusion(PROOF_BYTES, PUB_INPUT_BYTES);
         assert!(result);
     }
 
     #[test]
     fn empty_account_state_proof_does_not_verify() {
-        let proof_buffer = [0u8; super::MAX_PROOF_SIZE];
+        let proof_buffer = [0u8; PROOF_BYTES.len()];
         let proof_size = PROOF_BYTES.len();
 
         let mut pub_input_buffer = [0u8; super::MAX_PUB_INPUT_SIZE];
@@ -118,18 +108,13 @@ mod test {
         assert!(pub_input_size <= pub_input_buffer.len());
         pub_input_buffer[..pub_input_size].clone_from_slice(PUB_INPUT_BYTES);
 
-        let result = verify_account_inclusion_ffi(
-            &proof_buffer,
-            proof_size,
-            &pub_input_buffer,
-            pub_input_size,
-        );
+        let result = verify_account_inclusion(&proof_buffer, &pub_input_buffer, pub_input_size);
         assert!(!result);
     }
 
     #[test]
     fn valid_account_state_proof_with_empty_pub_input_does_not_verify() {
-        let mut proof_buffer = [0u8; super::MAX_PROOF_SIZE];
+        let mut proof_buffer = [0u8; PROOF_BYTES.len()];
         let proof_size = PROOF_BYTES.len();
         assert!(proof_size <= proof_buffer.len());
         proof_buffer[..proof_size].clone_from_slice(PROOF_BYTES);
@@ -148,7 +133,7 @@ mod test {
 
     #[test]
     fn valid_account_state_proof_with_greater_proof_size_does_not_verify() {
-        let mut proof_buffer = [0u8; super::MAX_PROOF_SIZE];
+        let mut proof_buffer = [0u8; PROOF_BYTES.len()];
         let wrong_proof_size = MAX_PROOF_SIZE + 1;
         proof_buffer[..PROOF_BYTES.len()].clone_from_slice(PROOF_BYTES);
 
@@ -168,7 +153,7 @@ mod test {
 
     #[test]
     fn valid_account_state_proof_with_greater_pub_input_size_does_not_verify() {
-        let mut proof_buffer = [0u8; super::MAX_PROOF_SIZE];
+        let mut proof_buffer = [0u8; PROOF_BYTES.len()];
         let proof_size = PROOF_BYTES.len();
         assert!(proof_size <= proof_buffer.len());
         proof_buffer[..proof_size].clone_from_slice(PROOF_BYTES);

--- a/operator/mina_account/mina_account.go
+++ b/operator/mina_account/mina_account.go
@@ -13,10 +13,6 @@ import (
 	"unsafe"
 )
 
-// TODO(xqft): check proof size
-const MAX_PROOF_SIZE = 16 * 1024
-const MAX_PUB_INPUT_SIZE = 6 * 1024
-
 func timer() func() {
 	start := time.Now()
 	return func() {
@@ -24,7 +20,7 @@ func timer() func() {
 	}
 }
 
-func VerifyAccountInclusion(proofBuffer [MAX_PROOF_SIZE]byte, proofLen uint, pubInputBuffer [MAX_PUB_INPUT_SIZE]byte, pubInputLen uint) bool {
+func VerifyAccountInclusion(proofBuffer []byte, proofLen uint, pubInputBuffer []byte, pubInputLen uint) bool {
 	defer timer()()
 	proofPtr := (*C.uchar)(unsafe.Pointer(&proofBuffer[0]))
 	pubInputPtr := (*C.uchar)(unsafe.Pointer(&pubInputBuffer[0]))

--- a/operator/mina_account/mina_account.go
+++ b/operator/mina_account/mina_account.go
@@ -9,20 +9,35 @@ package mina_account
 import "C"
 import (
 	"fmt"
-	"time"
 	"unsafe"
 )
 
-func timer() func() {
-	start := time.Now()
-	return func() {
-		fmt.Printf("Mina account verification took %v\n", time.Since(start))
+func VerifyAccountInclusion(proofBuffer []byte, pubInputBuffer []byte) (isVerified bool, err error) {
+	// Here we define the return value on failure
+	isVerified = false
+	err = nil
+	if len(proofBuffer) == 0 || len(pubInputBuffer) == 0 {
+		return isVerified, err
 	}
-}
 
-func VerifyAccountInclusion(proofBuffer []byte, proofLen uint, pubInputBuffer []byte, pubInputLen uint) bool {
-	defer timer()()
+	// This will catch any go panic
+	defer func() {
+		rec := recover()
+		if rec != nil {
+			err = fmt.Errorf("Panic was caught while verifying sp1 proof: %s", rec)
+		}
+	}()
+
 	proofPtr := (*C.uchar)(unsafe.Pointer(&proofBuffer[0]))
 	pubInputPtr := (*C.uchar)(unsafe.Pointer(&pubInputBuffer[0]))
-	return (bool)(C.verify_account_inclusion_ffi(proofPtr, (C.uint)(proofLen), pubInputPtr, (C.uint)(pubInputLen)))
+	r := (C.int32_t)(C.verify_account_inclusion_ffi(proofPtr, (C.uint32_t)(len(proofBuffer)), pubInputPtr, (C.uint32_t)(len(pubInputBuffer))))
+
+	if r == -1 {
+		err = fmt.Errorf("Panic happened on FFI while verifying Mina account proof")
+		return isVerified, err
+	}
+
+	isVerified = (r == 1)
+
+	return isVerified, err
 }

--- a/operator/mina_account/mina_account_test.go
+++ b/operator/mina_account/mina_account_test.go
@@ -1,76 +1,71 @@
 package mina_account_test
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
 	"github.com/yetanotherco/aligned_layer/operator/mina_account"
 )
 
+const ProofFilePath = "../../scripts/test_files/mina_account/mina_account.proof"
+
+const PubInputFilePath = "../../scripts/test_files/mina_account/mina_account.pub"
+
 func TestMinaStateProofVerifies(t *testing.T) {
-	fmt.Println(os.Getwd())
-	proofFile, err := os.Open("../../scripts/test_files/mina_account/mina_account.proof")
+	proofBytes, err := os.ReadFile(ProofFilePath)
 	if err != nil {
 		t.Errorf("could not open mina account proof file")
 	}
 
-	proofBuffer := make([]byte, mina_account.MAX_PROOF_SIZE)
-	proofLen, err := proofFile.Read(proofBuffer)
+	pubInputBytes, err := os.ReadFile(PubInputFilePath)
 	if err != nil {
-		t.Errorf("could not read bytes from mina account proof file")
+		t.Errorf("could not open mina account pub input file")
 	}
 
-	pubInputFile, err := os.Open("../../scripts/test_files/mina_account/mina_account.pub")
-	if err != nil {
-		t.Errorf("could not open mina account pub inputs file")
-	}
-	pubInputBuffer := make([]byte, mina_account.MAX_PUB_INPUT_SIZE)
-	pubInputLen, err := pubInputFile.Read(pubInputBuffer)
-	if err != nil {
-		t.Errorf("could not read bytes from mina account pub inputs hash")
-	}
-
-	if !mina_account.VerifyAccountInclusion(([mina_account.MAX_PROOF_SIZE]byte)(proofBuffer), uint(proofLen), ([mina_account.MAX_PUB_INPUT_SIZE]byte)(pubInputBuffer), uint(pubInputLen)) {
+	verified, err := mina_account.VerifyAccountInclusion(proofBytes, pubInputBytes)
+	if err != nil || !verified {
 		t.Errorf("proof did not verify")
 	}
 }
 
 func TestEmptyMinaStateProofDoesNotVerify(t *testing.T) {
-	fmt.Println(os.Getwd())
-	proofBuffer := make([]byte, mina_account.MAX_PROOF_SIZE)
-
-	pubInputFile, err := os.Open("../../scripts/test_files/mina_account/mina_account.pub")
+	proofBytes, err := os.ReadFile(ProofFilePath)
 	if err != nil {
-		t.Errorf("could not open mina account pub inputs file")
+		t.Errorf("could not open mina state proof file")
 	}
-	pubInputBuffer := make([]byte, mina_account.MAX_PUB_INPUT_SIZE)
-	pubInputLen, err := pubInputFile.Read(pubInputBuffer)
+	emptyProofBuffer := make([]byte, len(proofBytes))
+
+	pubInputBytes, err := os.ReadFile(PubInputFilePath)
 	if err != nil {
-		t.Errorf("could not read bytes from mina account pub inputs hash")
+		t.Errorf("could not open mina state pub input file")
 	}
 
-	if mina_account.VerifyAccountInclusion(([mina_account.MAX_PROOF_SIZE]byte)(proofBuffer), mina_account.MAX_PROOF_SIZE, ([mina_account.MAX_PUB_INPUT_SIZE]byte)(pubInputBuffer), uint(pubInputLen)) {
-		t.Errorf("Empty proof should not verify but it did")
+	verified, err := mina_account.VerifyAccountInclusion(emptyProofBuffer, pubInputBytes)
+	if err != nil {
+		t.Errorf("verification failed with error")
+	}
+	if verified {
+		t.Errorf("proof should not verify")
 	}
 }
 
 func TestMinaStateProofWithEmptyPubInputDoesNotVerify(t *testing.T) {
-	fmt.Println(os.Getwd())
-	proofFile, err := os.Open("../../scripts/test_files/mina_account/mina_account.proof")
+	proofBytes, err := os.ReadFile(ProofFilePath)
 	if err != nil {
-		t.Errorf("could not open mina account proof file")
+		t.Errorf("could not open mina state proof file")
 	}
 
-	proofBuffer := make([]byte, mina_account.MAX_PROOF_SIZE)
-	proofLen, err := proofFile.Read(proofBuffer)
+	pubInputBytes, err := os.ReadFile(PubInputFilePath)
 	if err != nil {
-		t.Errorf("could not read bytes from mina account proof file")
+		t.Errorf("could not open mina state pub input file")
 	}
+	emptyPubInputBuffer := make([]byte, len(pubInputBytes))
 
-	pubInputBuffer := make([]byte, mina_account.MAX_PUB_INPUT_SIZE)
-
-	if mina_account.VerifyAccountInclusion(([mina_account.MAX_PROOF_SIZE]byte)(proofBuffer), uint(proofLen), ([mina_account.MAX_PUB_INPUT_SIZE]byte)(pubInputBuffer), mina_account.MAX_PUB_INPUT_SIZE) {
-		t.Errorf("proof with empty public input should not verify but id did")
+	verified, err := mina_account.VerifyAccountInclusion(proofBytes, emptyPubInputBuffer)
+	if err != nil {
+		t.Errorf("verification failed with error")
+	}
+	if verified {
+		t.Errorf("proof should not verify")
 	}
 }

--- a/operator/pkg/operator.go
+++ b/operator/pkg/operator.go
@@ -533,24 +533,16 @@ func (o *Operator) verify(verificationData VerificationData, disabledVerifiersBi
 	case common.Mina:
 		proofLen := (uint)(len(verificationData.Proof))
 		pubInputLen := (uint)(len(verificationData.PubInput))
-		proofBuffer := make([]byte, mina.MAX_PROOF_SIZE)
-		copy(proofBuffer, verificationData.Proof)
-		pubInputBuffer := make([]byte, mina.MAX_PUB_INPUT_SIZE)
-		copy(pubInputBuffer, verificationData.PubInput)
 
-		verificationResult := mina.VerifyMinaState(([mina.MAX_PROOF_SIZE]byte)(proofBuffer), proofLen, ([mina.MAX_PUB_INPUT_SIZE]byte)(pubInputBuffer), (uint)(pubInputLen))
+		verificationResult := mina.VerifyMinaState(verificationData.Proof, proofLen, verificationData.PubInput, (uint)(pubInputLen))
 		o.Logger.Infof("Mina state proof verification result: %t", verificationResult)
 		// TODO: Remove the nil value passed as err argument
 		o.handleVerificationResult(results, verificationResult, nil, "Mina state proof verification")
 	case common.MinaAccount:
 		proofLen := (uint)(len(verificationData.Proof))
 		pubInputLen := (uint)(len(verificationData.PubInput))
-		proofBuffer := make([]byte, mina.MAX_PROOF_SIZE)
-		copy(proofBuffer, verificationData.Proof)
-		pubInputBuffer := make([]byte, mina.MAX_PUB_INPUT_SIZE)
-		copy(pubInputBuffer, verificationData.PubInput)
 
-		verificationResult := mina_account.VerifyAccountInclusion(([mina_account.MAX_PROOF_SIZE]byte)(proofBuffer), proofLen, ([mina_account.MAX_PUB_INPUT_SIZE]byte)(pubInputBuffer), (uint)(pubInputLen))
+		verificationResult := mina_account.VerifyAccountInclusion(verificationData.Proof, proofLen, verificationData.PubInput, (uint)(pubInputLen))
 		o.Logger.Infof("Mina account inclusion proof verification result: %t", verificationResult)
 		// TODO: Remove the nil value passed as err argument
 		o.handleVerificationResult(results, verificationResult, nil, "Mina account state proof verification")

--- a/operator/pkg/operator.go
+++ b/operator/pkg/operator.go
@@ -531,21 +531,13 @@ func (o *Operator) verify(verificationData VerificationData, disabledVerifiersBi
 		o.handleVerificationResult(results, verificationResult, err, "Risc0 proof verification")
 		results <- verificationResult
 	case common.Mina:
-		proofLen := (uint)(len(verificationData.Proof))
-		pubInputLen := (uint)(len(verificationData.PubInput))
-
-		verificationResult := mina.VerifyMinaState(verificationData.Proof, proofLen, verificationData.PubInput, (uint)(pubInputLen))
+		verificationResult, err := mina.VerifyMinaState(verificationData.Proof, verificationData.PubInput)
 		o.Logger.Infof("Mina state proof verification result: %t", verificationResult)
-		// TODO: Remove the nil value passed as err argument
-		o.handleVerificationResult(results, verificationResult, nil, "Mina state proof verification")
+		o.handleVerificationResult(results, verificationResult, err, "Mina state proof verification")
 	case common.MinaAccount:
-		proofLen := (uint)(len(verificationData.Proof))
-		pubInputLen := (uint)(len(verificationData.PubInput))
-
-		verificationResult := mina_account.VerifyAccountInclusion(verificationData.Proof, proofLen, verificationData.PubInput, (uint)(pubInputLen))
+		verificationResult, err := mina_account.VerifyAccountInclusion(verificationData.Proof, verificationData.PubInput)
 		o.Logger.Infof("Mina account inclusion proof verification result: %t", verificationResult)
-		// TODO: Remove the nil value passed as err argument
-		o.handleVerificationResult(results, verificationResult, nil, "Mina account state proof verification")
+		o.handleVerificationResult(results, verificationResult, err, "Mina account state proof verification")
 	default:
 		o.Logger.Error("Unrecognized proving system ID")
 		results <- false

--- a/operator/sp1/sp1.go
+++ b/operator/sp1/sp1.go
@@ -1,8 +1,8 @@
 package sp1
 
 /*
-#cgo linux LDFLAGS: ${SRCDIR}/lib/libsp1_verifier_ffi.so -ldl -lrt -lm -lssl -lcrypto -Wl,--allow-multiple-definition
 #cgo darwin LDFLAGS: -L./lib -lsp1_verifier_ffi
+#cgo linux LDFLAGS: ${SRCDIR}/lib/libsp1_verifier_ffi.so -ldl -lrt -lm -lssl -lcrypto -Wl,--allow-multiple-definition
 
 #include "lib/sp1.h"
 */


### PR DESCRIPTION
- Change proof and pub input types from array to C pointer
- Remove max size constants
- Now the batcher does not use FFI to verify Mina proofs